### PR TITLE
Migrate from UDP to TCP

### DIFF
--- a/src/lua/api.lua
+++ b/src/lua/api.lua
@@ -2,7 +2,6 @@ local socket = require("socket")
 local json = require("json")
 
 -- Constants
-local TCP_BUFFER_SIZE = 65536
 local SOCKET_TIMEOUT = 0
 -- The threshold for determining when game state transitions are complete.
 -- This value represents the maximum number of events allowed in the game's event queue
@@ -81,10 +80,7 @@ function API.update(_)
       API.client_socket = nil
     elseif err ~= "timeout" then
       sendDebugMessage("TCP receive error: " .. tostring(err), "API")
-      -- Don't close connection on timeout, only on real errors
-      if err ~= "timeout" then
-        API.client_socket = nil
-      end
+      API.client_socket = nil
     end
   end
 end

--- a/tests/test_api_functions.py
+++ b/tests/test_api_functions.py
@@ -1,4 +1,4 @@
-"""Tests for BalatroBot UDP API game functions."""
+"""Tests for BalatroBot TCP API game functions."""
 
 import socket
 from typing import Generator
@@ -14,20 +14,20 @@ class TestGetGameState:
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> Generator[None, None, None]:
         """Set up and tear down each test method."""
         yield
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
-    def test_get_game_state_response(self, udp_client: socket.socket) -> None:
+    def test_get_game_state_response(self, tcp_client: socket.socket) -> None:
         """Test get_game_state message returns valid JSON game state."""
-        game_state = send_and_receive_api_message(udp_client, "get_game_state", {})
+        game_state = send_and_receive_api_message(tcp_client, "get_game_state", {})
         assert isinstance(game_state, dict)
 
-    def test_game_state_structure(self, udp_client: socket.socket) -> None:
+    def test_game_state_structure(self, tcp_client: socket.socket) -> None:
         """Test that game state contains expected top-level fields."""
-        game_state = send_and_receive_api_message(udp_client, "get_game_state", {})
+        game_state = send_and_receive_api_message(tcp_client, "get_game_state", {})
 
         assert isinstance(game_state, dict)
 
@@ -36,7 +36,7 @@ class TestGetGameState:
         assert isinstance(game_state["state"], int)
         assert isinstance(game_state["game"], (dict, type(None)))
 
-    def test_game_state_during_run(self, udp_client: socket.socket) -> None:
+    def test_game_state_during_run(self, tcp_client: socket.socket) -> None:
         """Test getting game state at different points during a run."""
         # Start a run
         start_run_args = {
@@ -46,12 +46,12 @@ class TestGetGameState:
             "seed": "EXAMPLE",
         }
         initial_state = send_and_receive_api_message(
-            udp_client, "start_run", start_run_args
+            tcp_client, "start_run", start_run_args
         )
         assert initial_state["state"] == State.BLIND_SELECT.value
 
         # Get game state again to ensure it's consistent
-        current_state = send_and_receive_api_message(udp_client, "get_game_state", {})
+        current_state = send_and_receive_api_message(tcp_client, "get_game_state", {})
 
         assert current_state["state"] == State.BLIND_SELECT.value
         assert current_state["state"] == initial_state["state"]
@@ -62,13 +62,13 @@ class TestStartRun:
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> Generator[None, None, None]:
         """Set up and tear down each test method."""
         yield
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
-    def test_start_run(self, udp_client: socket.socket) -> None:
+    def test_start_run(self, tcp_client: socket.socket) -> None:
         """Test starting a run and verifying the state."""
         start_run_args = {
             "deck": "Red Deck",
@@ -77,12 +77,12 @@ class TestStartRun:
             "seed": "EXAMPLE",
         }
         game_state = send_and_receive_api_message(
-            udp_client, "start_run", start_run_args
+            tcp_client, "start_run", start_run_args
         )
 
         assert game_state["state"] == State.BLIND_SELECT.value
 
-    def test_start_run_with_challenge(self, udp_client: socket.socket) -> None:
+    def test_start_run_with_challenge(self, tcp_client: socket.socket) -> None:
         """Test starting a run with a challenge."""
         start_run_args = {
             "deck": "Red Deck",
@@ -91,13 +91,13 @@ class TestStartRun:
             "seed": "EXAMPLE",
         }
         game_state = send_and_receive_api_message(
-            udp_client, "start_run", start_run_args
+            tcp_client, "start_run", start_run_args
         )
 
         assert game_state["state"] == State.BLIND_SELECT.value
         assert len(game_state["jokers"]) == 5  # jokers in The Omelette challenge
 
-    def test_start_run_different_stakes(self, udp_client: socket.socket) -> None:
+    def test_start_run_different_stakes(self, tcp_client: socket.socket) -> None:
         """Test starting runs with different stake levels."""
         for stake in [1, 2, 3]:
             start_run_args = {
@@ -107,15 +107,15 @@ class TestStartRun:
                 "seed": "EXAMPLE",
             }
             game_state = send_and_receive_api_message(
-                udp_client, "start_run", start_run_args
+                tcp_client, "start_run", start_run_args
             )
 
             assert game_state["state"] == State.BLIND_SELECT.value
 
             # Go back to menu for next iteration
-            send_and_receive_api_message(udp_client, "go_to_menu", {})
+            send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
-    def test_start_run_missing_required_args(self, udp_client: socket.socket) -> None:
+    def test_start_run_missing_required_args(self, tcp_client: socket.socket) -> None:
         """Test start_run with missing required arguments."""
         # Missing deck
         incomplete_args = {
@@ -125,11 +125,11 @@ class TestStartRun:
         }
         # Should receive error response
         response = send_and_receive_api_message(
-            udp_client, "start_run", incomplete_args
+            tcp_client, "start_run", incomplete_args
         )
         assert_error_response(response, "Invalid deck arg for start_run")
 
-    def test_start_run_invalid_deck(self, udp_client: socket.socket) -> None:
+    def test_start_run_invalid_deck(self, tcp_client: socket.socket) -> None:
         """Test start_run with invalid deck name."""
         invalid_args = {
             "deck": "Nonexistent Deck",
@@ -138,19 +138,19 @@ class TestStartRun:
             "seed": "EXAMPLE",
         }
         # Should receive error response
-        response = send_and_receive_api_message(udp_client, "start_run", invalid_args)
+        response = send_and_receive_api_message(tcp_client, "start_run", invalid_args)
         assert_error_response(response, "Invalid deck arg for start_run", ["deck"])
 
 
 class TestGoToMenu:
     """Tests for the go_to_menu API endpoint."""
 
-    def test_go_to_menu(self, udp_client: socket.socket) -> None:
+    def test_go_to_menu(self, tcp_client: socket.socket) -> None:
         """Test going to the main menu."""
-        game_state = send_and_receive_api_message(udp_client, "go_to_menu", {})
+        game_state = send_and_receive_api_message(tcp_client, "go_to_menu", {})
         assert game_state["state"] == State.MENU.value
 
-    def test_go_to_menu_from_run(self, udp_client: socket.socket) -> None:
+    def test_go_to_menu_from_run(self, tcp_client: socket.socket) -> None:
         """Test going to menu from within a run."""
         # First start a run
         start_run_args = {
@@ -160,12 +160,12 @@ class TestGoToMenu:
             "seed": "EXAMPLE",
         }
         initial_state = send_and_receive_api_message(
-            udp_client, "start_run", start_run_args
+            tcp_client, "start_run", start_run_args
         )
         assert initial_state["state"] == State.BLIND_SELECT.value
 
         # Now go to menu
-        menu_state = send_and_receive_api_message(udp_client, "go_to_menu", {})
+        menu_state = send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
         assert menu_state["state"] == State.MENU.value
 
@@ -175,7 +175,7 @@ class TestSkipOrSelectBlind:
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> Generator[None, None, None]:
         """Set up and tear down each test method."""
         start_run_args = {
@@ -185,18 +185,18 @@ class TestSkipOrSelectBlind:
             "seed": "OOOO155",
         }
         game_state = send_and_receive_api_message(
-            udp_client, "start_run", start_run_args
+            tcp_client, "start_run", start_run_args
         )
         assert game_state["state"] == State.BLIND_SELECT.value
         yield
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
-    def test_select_blind(self, udp_client: socket.socket) -> None:
+    def test_select_blind(self, tcp_client: socket.socket) -> None:
         """Test selecting a blind during the blind selection phase."""
         # Select the blind
         select_blind_args = {"action": "select"}
         game_state = send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", select_blind_args
+            tcp_client, "skip_or_select_blind", select_blind_args
         )
 
         # Verify we get a valid game state response
@@ -205,12 +205,12 @@ class TestSkipOrSelectBlind:
         # Assert that there are 8 cards in the hand
         assert len(game_state["hand"]) == 8
 
-    def test_skip_blind(self, udp_client: socket.socket) -> None:
+    def test_skip_blind(self, tcp_client: socket.socket) -> None:
         """Test skipping a blind during the blind selection phase."""
         # Skip the blind
         skip_blind_args = {"action": "skip"}
         game_state = send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", skip_blind_args
+            tcp_client, "skip_or_select_blind", skip_blind_args
         )
 
         # Verify we get a valid game state response
@@ -219,12 +219,12 @@ class TestSkipOrSelectBlind:
         # Assert that the current blind is "Big", the "Small" blind was skipped
         assert game_state["game"]["blind_on_deck"] == "Big"
 
-    def test_skip_big_blind(self, udp_client: socket.socket) -> None:
+    def test_skip_big_blind(self, tcp_client: socket.socket) -> None:
         """Test complete flow: play small blind, cash out, skip shop, skip big blind."""
         # 1. Play small blind (select it)
         select_blind_args = {"action": "select"}
         game_state = send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", select_blind_args
+            tcp_client, "skip_or_select_blind", select_blind_args
         )
 
         # Verify we're in hand selection state
@@ -233,21 +233,21 @@ class TestSkipOrSelectBlind:
         # 2. Play winning hand (four of a kind)
         play_hand_args = {"action": "play_hand", "cards": [0, 1, 2, 3]}
         game_state = send_and_receive_api_message(
-            udp_client, "play_hand_or_discard", play_hand_args
+            tcp_client, "play_hand_or_discard", play_hand_args
         )
 
         # Verify we're in round evaluation state
         assert game_state["state"] == State.ROUND_EVAL.value
 
         # 3. Cash out to go to shop
-        game_state = send_and_receive_api_message(udp_client, "cash_out", {})
+        game_state = send_and_receive_api_message(tcp_client, "cash_out", {})
 
         # Verify we're in shop state
         assert game_state["state"] == State.SHOP.value
 
         # 4. Skip shop (next round)
         game_state = send_and_receive_api_message(
-            udp_client, "shop", {"action": "next_round"}
+            tcp_client, "shop", {"action": "next_round"}
         )
 
         # Verify we're back in blind selection state
@@ -256,18 +256,18 @@ class TestSkipOrSelectBlind:
         # 5. Skip the big blind
         skip_big_blind_args = {"action": "skip"}
         game_state = send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", skip_big_blind_args
+            tcp_client, "skip_or_select_blind", skip_big_blind_args
         )
 
         # Verify we successfully skipped the big blind and are still in blind selection
         assert game_state["state"] == State.BLIND_SELECT.value
 
-    def test_skip_both_blinds(self, udp_client: socket.socket) -> None:
+    def test_skip_both_blinds(self, tcp_client: socket.socket) -> None:
         """Test skipping small blind then immediately skipping big blind."""
         # 1. Skip the small blind
         skip_small_args = {"action": "skip"}
         game_state = send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", skip_small_args
+            tcp_client, "skip_or_select_blind", skip_small_args
         )
 
         # Verify we're still in blind selection and the big blind is on deck
@@ -277,17 +277,17 @@ class TestSkipOrSelectBlind:
         # 2. Skip the big blind
         skip_big_args = {"action": "skip"}
         game_state = send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", skip_big_args
+            tcp_client, "skip_or_select_blind", skip_big_args
         )
 
         # Verify we successfully skipped both blinds
         assert game_state["state"] == State.BLIND_SELECT.value
 
-    def test_invalid_blind_action(self, udp_client: socket.socket) -> None:
+    def test_invalid_blind_action(self, tcp_client: socket.socket) -> None:
         """Test that invalid blind action arguments are handled properly."""
         # Should receive error response
         error_response = send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", {"action": "invalid_action"}
+            tcp_client, "skip_or_select_blind", {"action": "invalid_action"}
         )
 
         # Verify error response
@@ -296,15 +296,15 @@ class TestSkipOrSelectBlind:
         )
 
     def test_skip_or_select_blind_invalid_state(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> None:
         """Test that skip_or_select_blind returns error when not in blind selection state."""
         # Go to menu to ensure we're not in blind selection state
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
         # Try to select blind when not in blind selection state
         error_response = send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", {"action": "select"}
+            tcp_client, "skip_or_select_blind", {"action": "select"}
         )
 
         # Verify error response
@@ -320,11 +320,11 @@ class TestPlayHandOrDiscard:
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> Generator[dict, None, None]:
         """Set up and tear down each test method."""
         send_and_receive_api_message(
-            udp_client,
+            tcp_client,
             "start_run",
             {
                 "deck": "Red Deck",
@@ -334,13 +334,13 @@ class TestPlayHandOrDiscard:
             },
         )
         game_state = send_and_receive_api_message(
-            udp_client,
+            tcp_client,
             "skip_or_select_blind",
             {"action": "select"},
         )
         assert game_state["state"] == State.SELECTING_HAND.value
         yield game_state
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
     @pytest.mark.parametrize(
         "cards,expected_new_cards",
@@ -351,7 +351,7 @@ class TestPlayHandOrDiscard:
     )
     def test_play_hand(
         self,
-        udp_client: socket.socket,
+        tcp_client: socket.socket,
         setup_and_teardown: dict,
         cards: list[int],
         expected_new_cards: int,
@@ -368,7 +368,7 @@ class TestPlayHandOrDiscard:
             for i in play_hand_args["cards"]
         ]
         game_state = send_and_receive_api_message(
-            udp_client, "play_hand_or_discard", play_hand_args
+            tcp_client, "play_hand_or_discard", play_hand_args
         )
         final_card_keys = [
             card["config"]["card"]["card_key"] for card in game_state["hand"]
@@ -378,31 +378,31 @@ class TestPlayHandOrDiscard:
         assert len(set(final_card_keys) - set(init_card_keys)) == expected_new_cards
         assert set(final_card_keys) & set(played_hand_keys) == set()
 
-    def test_play_hand_winning(self, udp_client: socket.socket) -> None:
+    def test_play_hand_winning(self, tcp_client: socket.socket) -> None:
         """Test playing a winning hand (four of a kind)"""
         play_hand_args = {"action": "play_hand", "cards": [0, 1, 2, 3]}
         game_state = send_and_receive_api_message(
-            udp_client, "play_hand_or_discard", play_hand_args
+            tcp_client, "play_hand_or_discard", play_hand_args
         )
         assert game_state["state"] == State.ROUND_EVAL.value
 
-    def test_play_hands_losing(self, udp_client: socket.socket) -> None:
+    def test_play_hands_losing(self, tcp_client: socket.socket) -> None:
         """Test playing a series of losing hands and reach Main menu again."""
         for _ in range(4):
             game_state = send_and_receive_api_message(
-                udp_client,
+                tcp_client,
                 "play_hand_or_discard",
                 {"action": "play_hand", "cards": [0]},
             )
         assert game_state["state"] == State.GAME_OVER.value
 
     def test_play_hand_or_discard_invalid_cards(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> None:
         """Test playing a hand with invalid card indices returns error."""
         play_hand_args = {"action": "play_hand", "cards": [10, 11, 12, 13, 14]}
         response = send_and_receive_api_message(
-            udp_client, "play_hand_or_discard", play_hand_args
+            tcp_client, "play_hand_or_discard", play_hand_args
         )
 
         # Should receive error response for invalid card index
@@ -410,11 +410,11 @@ class TestPlayHandOrDiscard:
             response, "Invalid card index", ["card_index", "hand_size"]
         )
 
-    def test_play_hand_invalid_action(self, udp_client: socket.socket) -> None:
+    def test_play_hand_invalid_action(self, tcp_client: socket.socket) -> None:
         """Test playing a hand with invalid action returns error."""
         play_hand_args = {"action": "invalid_action", "cards": [0, 1, 2, 3, 4]}
         response = send_and_receive_api_message(
-            udp_client, "play_hand_or_discard", play_hand_args
+            tcp_client, "play_hand_or_discard", play_hand_args
         )
 
         # Should receive error response for invalid action
@@ -431,7 +431,7 @@ class TestPlayHandOrDiscard:
     )
     def test_discard(
         self,
-        udp_client: socket.socket,
+        tcp_client: socket.socket,
         setup_and_teardown: dict,
         cards: list[int],
         expected_new_cards: int,
@@ -451,7 +451,7 @@ class TestPlayHandOrDiscard:
             for i in discard_hand_args["cards"]
         ]
         game_state = send_and_receive_api_message(
-            udp_client, "play_hand_or_discard", discard_hand_args
+            tcp_client, "play_hand_or_discard", discard_hand_args
         )
         final_card_keys = [
             card["config"]["card"]["card_key"] for card in game_state["hand"]
@@ -466,12 +466,12 @@ class TestPlayHandOrDiscard:
         assert set(final_card_keys) & set(discarded_hand_keys) == set()
 
     def test_try_to_discard_when_no_discards_left(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> None:
         """Test trying to discard when no discards are left."""
         for _ in range(4):
             game_state = send_and_receive_api_message(
-                udp_client,
+                tcp_client,
                 "play_hand_or_discard",
                 {"action": "discard", "cards": [0]},
             )
@@ -480,7 +480,7 @@ class TestPlayHandOrDiscard:
         assert game_state["game"]["current_round"]["discards_left"] == 0
 
         response = send_and_receive_api_message(
-            udp_client,
+            tcp_client,
             "play_hand_or_discard",
             {"action": "discard", "cards": [0]},
         )
@@ -491,15 +491,15 @@ class TestPlayHandOrDiscard:
         )
 
     def test_play_hand_or_discard_invalid_state(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> None:
         """Test that play_hand_or_discard returns error when not in selecting hand state."""
         # Go to menu to ensure we're not in selecting hand state
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
         # Try to play hand when not in selecting hand state
         error_response = send_and_receive_api_message(
-            udp_client,
+            tcp_client,
             "play_hand_or_discard",
             {"action": "play_hand", "cards": [0, 1, 2, 3, 4]},
         )
@@ -517,7 +517,7 @@ class TestShop:
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> Generator[None, None, None]:
         """Set up and tear down each test method."""
         # Start a run
@@ -527,55 +527,55 @@ class TestShop:
             "challenge": None,
             "seed": "OOOO155",  # four of a kind in first hand
         }
-        send_and_receive_api_message(udp_client, "start_run", start_run_args)
+        send_and_receive_api_message(tcp_client, "start_run", start_run_args)
 
         # Select blind
         send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", {"action": "select"}
+            tcp_client, "skip_or_select_blind", {"action": "select"}
         )
 
         # Play a winning hand (four of a kind) to reach shop
         game_state = send_and_receive_api_message(
-            udp_client,
+            tcp_client,
             "play_hand_or_discard",
             {"action": "play_hand", "cards": [0, 1, 2, 3]},
         )
         assert game_state["state"] == State.ROUND_EVAL.value
 
         # Cash out to reach shop
-        game_state = send_and_receive_api_message(udp_client, "cash_out", {})
+        game_state = send_and_receive_api_message(tcp_client, "cash_out", {})
         assert game_state["state"] == State.SHOP.value
         yield
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
-    def test_shop_next_round_success(self, udp_client: socket.socket) -> None:
+    def test_shop_next_round_success(self, tcp_client: socket.socket) -> None:
         """Test successful shop next_round action transitions to blind select."""
         # Execute next_round action
         game_state = send_and_receive_api_message(
-            udp_client, "shop", {"action": "next_round"}
+            tcp_client, "shop", {"action": "next_round"}
         )
 
         # Verify we're in blind select state after next_round
         assert game_state["state"] == State.BLIND_SELECT.value
 
-    def test_shop_invalid_action_error(self, udp_client: socket.socket) -> None:
+    def test_shop_invalid_action_error(self, tcp_client: socket.socket) -> None:
         """Test shop returns error for invalid action."""
         # Try invalid action
         response = send_and_receive_api_message(
-            udp_client, "shop", {"action": "invalid_action"}
+            tcp_client, "shop", {"action": "invalid_action"}
         )
 
         # Verify error response
         assert_error_response(response, "Invalid action arg for shop", ["action"])
 
-    def test_shop_invalid_state_error(self, udp_client: socket.socket) -> None:
+    def test_shop_invalid_state_error(self, tcp_client: socket.socket) -> None:
         """Test shop returns error when not in shop state."""
         # Go to menu first to ensure we're not in shop state
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
         # Try to use shop when not in shop state - should return error
         response = send_and_receive_api_message(
-            udp_client, "shop", {"action": "next_round"}
+            tcp_client, "shop", {"action": "next_round"}
         )
 
         # Verify error response
@@ -589,7 +589,7 @@ class TestCashOut:
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> Generator[None, None, None]:
         """Set up and tear down each test method."""
         # Start a run
@@ -599,38 +599,38 @@ class TestCashOut:
             "challenge": None,
             "seed": "OOOO155",  # four of a kind in first hand
         }
-        send_and_receive_api_message(udp_client, "start_run", start_run_args)
+        send_and_receive_api_message(tcp_client, "start_run", start_run_args)
 
         # Select blind
         send_and_receive_api_message(
-            udp_client, "skip_or_select_blind", {"action": "select"}
+            tcp_client, "skip_or_select_blind", {"action": "select"}
         )
 
         # Play a winning hand (four of a kind) to reach shop
         game_state = send_and_receive_api_message(
-            udp_client,
+            tcp_client,
             "play_hand_or_discard",
             {"action": "play_hand", "cards": [0, 1, 2, 3]},
         )
         assert game_state["state"] == State.ROUND_EVAL.value
         yield
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
-    def test_cash_out_success(self, udp_client: socket.socket) -> None:
+    def test_cash_out_success(self, tcp_client: socket.socket) -> None:
         """Test successful cash out returns to shop state."""
         # Cash out should transition to shop state
-        game_state = send_and_receive_api_message(udp_client, "cash_out", {})
+        game_state = send_and_receive_api_message(tcp_client, "cash_out", {})
 
         # Verify we're in shop state after cash out
         assert game_state["state"] == State.SHOP.value
 
-    def test_cash_out_invalid_state_error(self, udp_client: socket.socket) -> None:
+    def test_cash_out_invalid_state_error(self, tcp_client: socket.socket) -> None:
         """Test cash out returns error when not in shop state."""
         # Go to menu first to ensure we're not in shop state
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
         # Try to cash out when not in shop - should return error
-        response = send_and_receive_api_message(udp_client, "cash_out", {})
+        response = send_and_receive_api_message(tcp_client, "cash_out", {})
 
         # Verify error response
         assert_error_response(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,14 +4,7 @@ import json
 import socket
 
 import pytest
-from conftest import (
-    BUFFER_SIZE,
-    HOST,
-    PORT,
-    assert_error_response,
-    send_api_message,
-    receive_api_message,
-)
+from conftest import HOST, assert_error_response, receive_api_message, send_api_message
 
 
 def test_basic_connection(tcp_client: socket.socket) -> None:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,33 +1,34 @@
-"""Tests for BalatroBot UDP API connection and protocol handling."""
+"""Tests for BalatroBot TCP API connection and protocol handling."""
 
 import json
 import socket
 
 import pytest
-from conftest import BUFFER_SIZE, HOST, PORT, assert_error_response, send_api_message
+from conftest import (
+    BUFFER_SIZE,
+    HOST,
+    PORT,
+    assert_error_response,
+    send_api_message,
+    receive_api_message,
+)
 
 
-def test_basic_connection(udp_client: socket.socket) -> None:
-    """Test basic UDP connection and response."""
-    send_api_message(udp_client, "get_game_state", {})
+def test_basic_connection(tcp_client: socket.socket) -> None:
+    """Test basic TCP connection and response."""
+    send_api_message(tcp_client, "get_game_state", {})
 
-    data, addr = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-
-    game_state = json.loads(response)
+    game_state = receive_api_message(tcp_client)
     assert isinstance(game_state, dict)
-    assert addr[0] == HOST
 
 
-def test_rapid_messages(udp_client: socket.socket) -> None:
+def test_rapid_messages(tcp_client: socket.socket) -> None:
     """Test rapid succession of get_game_state messages."""
     responses = []
 
     for _ in range(3):
-        send_api_message(udp_client, "get_game_state", {})
-        data, _ = udp_client.recvfrom(BUFFER_SIZE)
-        response = data.decode().strip()
-        game_state = json.loads(response)
+        send_api_message(tcp_client, "get_game_state", {})
+        game_state = receive_api_message(tcp_client)
         responses.append(game_state)
 
     assert all(isinstance(resp, dict) for resp in responses)
@@ -36,121 +37,89 @@ def test_rapid_messages(udp_client: socket.socket) -> None:
 
 def test_connection_timeout() -> None:
     """Test behavior when no server is listening."""
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(0.2)
-        message = {"name": "get_game_state", "arguments": json.dumps({})}
-        sock.sendto(json.dumps(message).encode(), (HOST, 12345))  # Unused port
 
-        with pytest.raises(socket.timeout):
-            sock.recvfrom(1024)
+        with pytest.raises((socket.timeout, ConnectionRefusedError)):
+            sock.connect((HOST, 12345))  # Unused port
 
 
-def test_invalid_json_message(udp_client: socket.socket) -> None:
+def test_invalid_json_message(tcp_client: socket.socket) -> None:
     """Test that invalid JSON messages return error responses."""
     # Send invalid JSON
-    udp_client.sendto(b"invalid json", (HOST, PORT))
+    tcp_client.send(b"invalid json\n")
 
     # Should receive error response for invalid JSON
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-    error_response = json.loads(response)
+    error_response = receive_api_message(tcp_client)
     assert_error_response(error_response, "Invalid JSON")
 
     # Verify server is still responsive
-    send_api_message(udp_client, "get_game_state", {})
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-
-    # Should still get valid JSON response
-    game_state = json.loads(response)
+    send_api_message(tcp_client, "get_game_state", {})
+    game_state = receive_api_message(tcp_client)
     assert isinstance(game_state, dict)
 
 
-def test_missing_name_field(udp_client: socket.socket) -> None:
+def test_missing_name_field(tcp_client: socket.socket) -> None:
     """Test message without name field returns error response."""
-    message = {"arguments": json.dumps({})}
-    udp_client.sendto(json.dumps(message).encode(), (HOST, PORT))
+    message = {"arguments": {}}
+    tcp_client.send(json.dumps(message).encode() + b"\n")
 
     # Should receive error response for missing name field
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-    error_response = json.loads(response)
+    error_response = receive_api_message(tcp_client)
     assert_error_response(error_response, "Message must contain a name")
 
     # Verify server is still responsive
-    send_api_message(udp_client, "get_game_state", {})
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-
-    # Should still get valid JSON response
-    game_state = json.loads(response)
+    send_api_message(tcp_client, "get_game_state", {})
+    game_state = receive_api_message(tcp_client)
     assert isinstance(game_state, dict)
 
 
-def test_missing_arguments_field(udp_client: socket.socket) -> None:
+def test_missing_arguments_field(tcp_client: socket.socket) -> None:
     """Test message without arguments field returns error response."""
     message = {"name": "get_game_state"}
-    udp_client.sendto(json.dumps(message).encode(), (HOST, PORT))
+    tcp_client.send(json.dumps(message).encode() + b"\n")
 
     # Should receive error response for missing arguments field
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-    error_response = json.loads(response)
+    error_response = receive_api_message(tcp_client)
     assert_error_response(error_response, "Message must contain arguments")
 
     # Verify server is still responsive
-    send_api_message(udp_client, "get_game_state", {})
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-
-    # Should still get valid JSON response
-    game_state = json.loads(response)
+    send_api_message(tcp_client, "get_game_state", {})
+    game_state = receive_api_message(tcp_client)
     assert isinstance(game_state, dict)
 
 
-def test_unknown_message(udp_client: socket.socket) -> None:
+def test_unknown_message(tcp_client: socket.socket) -> None:
     """Test that unknown messages return error responses."""
     # Send unknown message
-    send_api_message(udp_client, "unknown_function", {})
+    send_api_message(tcp_client, "unknown_function", {})
 
     # Should receive error response for unknown function
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-    error_response = json.loads(response)
+    error_response = receive_api_message(tcp_client)
     assert_error_response(error_response, "Unknown function name", ["name"])
 
     # Verify server is still responsive
-    send_api_message(udp_client, "get_game_state", {})
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-
-    # Should still get valid JSON response
-    game_state = json.loads(response)
+    send_api_message(tcp_client, "get_game_state", {})
+    game_state = receive_api_message(tcp_client)
     assert isinstance(game_state, dict)
 
 
-def test_large_message_handling(udp_client: socket.socket) -> None:
-    """Test handling of large messages within UDP limits."""
+def test_large_message_handling(tcp_client: socket.socket) -> None:
+    """Test handling of large messages within TCP limits."""
     # Create a large but valid message
     large_args = {"data": "x" * 1000}  # 1KB of data
-    send_api_message(udp_client, "get_game_state", large_args)
+    send_api_message(tcp_client, "get_game_state", large_args)
 
     # Should still get a response
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-    game_state = json.loads(response)
+    game_state = receive_api_message(tcp_client)
     assert isinstance(game_state, dict)
 
 
-def test_empty_message(udp_client: socket.socket) -> None:
+def test_empty_message(tcp_client: socket.socket) -> None:
     """Test sending an empty message."""
-    udp_client.sendto(b"", (HOST, PORT))
+    tcp_client.send(b"\n")
 
     # Verify server is still responsive
-    send_api_message(udp_client, "get_game_state", {})
-    data, _ = udp_client.recvfrom(BUFFER_SIZE)
-    response = data.decode().strip()
-
-    # Should still get valid JSON response
-    game_state = json.loads(response)
+    send_api_message(tcp_client, "get_game_state", {})
+    game_state = receive_api_message(tcp_client)
     assert isinstance(game_state, dict)

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -31,18 +31,18 @@ class TestRunReplays:
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(
-        self, udp_client: socket.socket
+        self, tcp_client: socket.socket
     ) -> Generator[None, None, None]:
         """Set up and tear down each test method."""
         yield
-        send_and_receive_api_message(udp_client, "go_to_menu", {})
+        send_and_receive_api_message(tcp_client, "go_to_menu", {})
 
     @pytest.mark.parametrize("jsonl_file", get_jsonl_files())
-    def test_replay_run(self, udp_client: socket.socket, jsonl_file: Path) -> None:
+    def test_replay_run(self, tcp_client: socket.socket, jsonl_file: Path) -> None:
         """Test replaying a complete run from JSONL file.
 
         Args:
-            udp_client: UDP socket for API communication
+            tcp_client: UDP socket for API communication
             jsonl_file: Path to JSONL file containing recorded run
         """
         steps = load_jsonl_run(jsonl_file)
@@ -53,7 +53,7 @@ class TestRunReplays:
 
             # Call the API function with recorded parameters
             actual_game_state = send_and_receive_api_message(
-                udp_client, function_call["name"], function_call["params"]
+                tcp_client, function_call["name"], function_call["params"]
             )
 
             # Compare with the game_state from the next step (if it exists)


### PR DESCRIPTION
This PR migrates the BalatroBot API from UDP to TCP socket communication to provide reliable delivery and ordered data transmission while maintaining the same JSON API interface.
