### PR TITLE
fix: fast profile for balatro

### DIFF
--- a/src/lua/settings.lua
+++ b/src/lua/settings.lua
@@ -7,7 +7,7 @@ SETTINGS = {}
 
 -- BalatroBot Configuration
 local config = {
-  dt = fast and (4.0 / 60.0) or (1.0 / 60.0),
+  dt = headless and (4.99 / 60.0) or (1.0 / 60.0),
   headless = headless,
   fast = fast,
 }


### PR DESCRIPTION
Closes #83

Change dt break the UI. Now we change the dt just for headless mode (and make it even faster).