### PR TITLE
docs(api): Adding missing cards to GameState documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -701,6 +701,7 @@ The complete game state returned by most methods.
   "blinds": { ... },
   "jokers": { ... },
   "consumables": { ... },
+  "cards": { ... },
   "hand": { ... },
   "shop": { ... },
   "vouchers": { ... },


### PR DESCRIPTION
Adding missing cards to GameState documentation.

I checked types.lua, as well as openrpc.json and it looks like GameState.cards is in all of those places, so I think it was just a docs miss.