### PR TITLE
fix(linux): respect pre-existing STEAM_COMPAT_DATA_PATH and STEAM_COMPAT_CLIENT_INSTALL_PATH env vars

### DIFF
--- a/src/balatrobot/platforms/linux.py
+++ b/src/balatrobot/platforms/linux.py
@@ -104,10 +104,12 @@ class LinuxLauncher(BaseLauncher):
         env = os.environ.copy()
         env["WINEDLLOVERRIDES"] = "version=n,b"
 
+        # Don't override user-set env vars (e.g. custom Wine prefix, Proton version)
         steam_root = _detect_steam_root()
-        if steam_root:
+        if steam_root and "STEAM_COMPAT_CLIENT_INSTALL_PATH" not in env:
             env["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = str(steam_root)
-            compat_data = _detect_compat_data_path(steam_root)
+        if "STEAM_COMPAT_DATA_PATH" not in env:
+            compat_data = _detect_compat_data_path(steam_root) if steam_root else None
             if compat_data:
                 env["STEAM_COMPAT_DATA_PATH"] = str(compat_data)
 


### PR DESCRIPTION
Previously the Linux launcher unconditionally overwrote these env vars
with auto-detected Steam paths. Users with a custom Wine prefix
(e.g. Lutris) or non-standard Steam layout couldn't override them
via environment variables.

Now the launcher only sets these values if they aren't already set
in the environment, allowing users to specify a custom prefix or
Proton setup.
