### PR TITLE
feat(gamestate): expose last_tarot_planet for The Fool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,3 +169,5 @@ Error responses follow JSON-RPC 2.0 format:
   "id": 1
 }
 ```
+
+**Gotcha — The Fool / `last_tarot_planet`:** Balatro stores the card The Fool would create in `G.GAME.last_tarot_planet` (a key like `c_hermit`). Expose it on GameState as optional `last_tarot_planet`. Omit when unset. Using The Fool itself sets the value to `c_fool`, which The Fool cannot copy again until another Tarot/Planet is used.

--- a/docs/api.md
+++ b/docs/api.md
@@ -696,6 +696,7 @@ The complete game state returned by most methods.
   "deck": "RED",
   "stake": "WHITE",
   "seed": "ABC123",
+  "last_tarot_planet": "c_hermit",
   "won": false,
   "used_vouchers": {},
   "hands": { ... },
@@ -711,6 +712,8 @@ The complete game state returned by most methods.
   "pack": { ... }
 }
 ```
+
+`last_tarot_planet` is the card key The Fool would create (e.g. `c_hermit`). It is omitted when no Tarot or Planet has been used yet this run.
 
 ### Area
 
@@ -932,6 +935,8 @@ Card keys are used with the `add` method and appear in the `key` field of Card o
 #### Tarot Cards
 
 Consumables that enhance playing cards, change suits, generate other cards, or provide money. Keys use prefix `c_` followed by the card name (e.g., `c_fool`, `c_magician`). 22 cards total.
+
+The card The Fool would create is exposed on GameState as `last_tarot_planet`.
 
 | Key                  | Effect                                                                          |
 | -------------------- | ------------------------------------------------------------------------------- |

--- a/src/lua/utils/gamestate.lua
+++ b/src/lua/utils/gamestate.lua
@@ -754,6 +754,11 @@ function gamestate.get_gamestate()
       state_data.seed = G.GAME.pseudorandom.seed
     end
 
+    -- Last Tarot/Planet used (what The Fool would create; omitted when none)
+    if G.GAME.last_tarot_planet then
+      state_data.last_tarot_planet = G.GAME.last_tarot_planet
+    end
+
     -- Used vouchers (table<string, string>)
     if G.GAME.used_vouchers then
       local used_vouchers = {}

--- a/src/lua/utils/openrpc.json
+++ b/src/lua/utils/openrpc.json
@@ -902,6 +902,10 @@
             "type": "string",
             "description": "Seed used for the run"
           },
+          "last_tarot_planet": {
+            "type": "string",
+            "description": "Key of the last Tarot or Planet card used during this run (what The Fool would create). Omitted when none has been used yet."
+          },
           "won": {
             "type": "boolean",
             "description": "Whether the game has been won"

--- a/src/lua/utils/types.lua
+++ b/src/lua/utils/types.lua
@@ -12,6 +12,7 @@
 ---@field deck Deck? Current selected deck
 ---@field stake Stake? Current selected stake
 ---@field seed string? Seed used for the run
+---@field last_tarot_planet string? Key of the last Tarot or Planet used this run (what The Fool copies); omitted when none
 ---@field state State Current game state
 ---@field round_num integer Current round number
 ---@field ante_num integer Current ante number

--- a/tests/lua/endpoints/test_gamestate.py
+++ b/tests/lua/endpoints/test_gamestate.py
@@ -89,6 +89,28 @@ class TestGamestateTopLevel:
         response = api(client, "play", {"cards": [0]})
         assert response["result"]["won"] is True
 
+    def test_last_tarot_planet_absent_at_run_start(self, client: httpx.Client) -> None:
+        """Fresh runs have no last Tarot/Planet for The Fool to copy."""
+        fixture_name = "state-SELECTING_HAND"
+        gamestate = load_fixture(client, "gamestate", fixture_name)
+        assert gamestate.get("last_tarot_planet") is None
+
+    def test_last_tarot_planet_after_using_tarot(self, client: httpx.Client) -> None:
+        """Using a Tarot updates last_tarot_planet to that card key."""
+        load_fixture(client, "gamestate", "state-SELECTING_HAND")
+        api(client, "add", {"key": "c_hermit"})
+        response = api(client, "use", {"consumable": 0})
+        after = assert_gamestate_response(response)
+        assert after["last_tarot_planet"] == "c_hermit"
+
+    def test_last_tarot_planet_after_using_planet(self, client: httpx.Client) -> None:
+        """Using a Planet updates last_tarot_planet to that card key."""
+        load_fixture(client, "gamestate", "state-SELECTING_HAND")
+        api(client, "add", {"key": "c_pluto"})
+        response = api(client, "use", {"consumable": 0})
+        after = assert_gamestate_response(response)
+        assert after["last_tarot_planet"] == "c_pluto"
+
 
 class TestGamestateRound:
     """Test gamestate round extraction."""


### PR DESCRIPTION
## Summary
- Expose optional `last_tarot_planet` on GameState from `G.GAME.last_tarot_planet` (card key The Fool would create, e.g. `c_hermit`).
- Omitted when no Tarot/Planet has been used yet this run.
- Document in OpenRPC, `docs/api.md`, and Lua types; add integration tests.

## Test plan
- [ ] `uv run pytest tests/lua/endpoints/test_gamestate.py::TestGamestateTopLevel::test_last_tarot_planet_absent_at_run_start -v`
- [ ] `uv run pytest tests/lua/endpoints/test_gamestate.py::TestGamestateTopLevel::test_last_tarot_planet_after_using_tarot -v`
- [ ] `uv run pytest tests/lua/endpoints/test_gamestate.py::TestGamestateTopLevel::test_last_tarot_planet_after_using_planet -v`
- [ ] Manually: start a run, `gamestate` has no `last_tarot_planet`; use Hermit; `gamestate` shows last_tarot_planet: c_hermit`