### PR TITLE
fix(sell): allow selling during SMODS_BOOSTER_OPENED

### DIFF
--- a/src/lua/endpoints/sell.lua
+++ b/src/lua/endpoints/sell.lua
@@ -32,7 +32,7 @@ return {
     },
   },
 
-  requires_state = { G.STATES.SELECTING_HAND, G.STATES.SHOP },
+  requires_state = { G.STATES.SELECTING_HAND, G.STATES.SHOP, G.STATES.SMODS_BOOSTER_OPENED },
 
   ---@param args Request.Endpoint.Sell.Params
   ---@param send_response fun(response: Response.Endpoint)
@@ -144,7 +144,11 @@ return {
         local state_stable = G.STATE_COMPLETE == true
 
         -- 5. Still in valid state
-        local valid_state = (G.STATE == G.STATES.SHOP or G.STATE == G.STATES.SELECTING_HAND)
+        local valid_state = (
+          G.STATE == G.STATES.SHOP
+          or G.STATE == G.STATES.SELECTING_HAND
+          or G.STATE == G.STATES.SMODS_BOOSTER_OPENED
+        )
 
         -- All conditions must be met
         if count_decreased and money_increased and card_gone and state_stable and valid_state then


### PR DESCRIPTION
## Problem

`sell`'s `requires_state` only allows `SELECTING_HAND` and `SHOP`. When a
Buffoon pack is opened while the Joker roster is already full (5/5), there's
no way to make room via the API before picking a card from the pack — even
though the base game's own UI lets you sell a Joker from the booster pack
screen. Any Joker offered by the pack (including a Legendary pulled from a
Soul card) is effectively unreachable in that situation; the only workaround
is skipping the whole pack.

## Fix

Adds `G.STATES.SMODS_BOOSTER_OPENED` to `sell`'s `requires_state`, and to the
completion-check's `valid_state` condition further down (the polling event
that waits for the sell to finish also gates on state, so both places needed
the change or the request just hangs waiting for a state transition that
never happens).

## Testing

Tested manually against a running instance via the debug `add`/`set`
endpoints: filled Jokers to 5/5, opened a booster pack, called
`sell` with `joker: 0` while `state == SMODS_BOOSTER_OPENED`. Before the fix
this returns `INVALID_STATE`. After the fix it sells normally — card count
and money update correctly, game state stays consistent and still reports
`SMODS_BOOSTER_OPENED` — and the pack can then be resolved as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)